### PR TITLE
Add MathJax script for correct markdown math display

### DIFF
--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -6,5 +6,4 @@
 {% endcomment %}
 
 <link rel="stylesheet" href="{{ "/assets/custom.css" | relative_url }}">
-
-
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>


### PR DESCRIPTION
Math display in markdown was not correctly supported in Jekyll without [MathJax](https://medium.com/coffee-in-a-klein-bottle/creating-a-mathematics-blog-with-jekyll-78cdee0339f3). This meant that [our report](https://luiscruz.github.io/course_sustainableSE/2023/p1_measuring_software/g6_power_profiles.html) was not working as expected.

This PR adds the MathJax dependency in `custom-head.html`.

### Before:
![image](https://user-images.githubusercontent.com/33723189/224988469-639aa4f7-a889-4aa7-8734-c1b3b05fcd28.png)

### After:
![image](https://user-images.githubusercontent.com/33723189/224988590-cefda6e7-b803-422c-88e5-1937041c9428.png)
