### PR TITLE
Move p2 to p2_hacking_sustainability for markdown view

### DIFF
--- a/2023/index.md
+++ b/2023/index.md
@@ -129,7 +129,7 @@ Below the description of each project.
 - **Weight in final grade**: 60% (extra 7.5% for the presentation)
 - **Steering meeting/formative assessments**: Every week from week 5 to 9.
 - **Deadline** Friday, March 31. (Grace period until April 14).
-- Submission by pull request to the website. Instructions [here](/course_sustainableSE/2023/p2). **⭐️(new)**
+- Submission by pull request to the website. Instructions [here](/course_sustainableSE/2023/p2_hacking_sustainability/). **⭐️(new)**
 
  
 

--- a/2023/p2_hacking_sustainability/g10_greensoftware_procurement.md
+++ b/2023/p2_hacking_sustainability/g10_greensoftware_procurement.md
@@ -1,9 +1,9 @@
 ---
 author: Valentijn van de Beek, Merlijn Mac Gillavry, Leon de Klerk, Joey de Water
 title: "Green software procurement"
-image: "img/p2_hacking_sustainability/gX_template/cover.png"
+image: "../img/p2_hacking_sustainability/gX_template/cover.png"
 summary: "This is a summary with a max of 200 characters; Lorem ipsum dolor sit amet, consectetur adipisicing elit, dos eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis."
-paper: "papers/g10_paper.pdf"
+paper: "../papers/g10_paper.pdf"
 source: "https://github.com/leondeklerk/SSE/tree/master/project_2"
 website: https://luiscruz.github.io/course_sustainableSE/2023/
 ---

--- a/2023/p2_hacking_sustainability/g12_carbon_tracker.md
+++ b/2023/p2_hacking_sustainability/g12_carbon_tracker.md
@@ -1,7 +1,7 @@
 ---
 author: Elias Stenhede Johansson, Gustav Leth-Espensen, Florian Ecker-Eckhofen, Gustav Emil Nobert
 title: "Carbon Tracker Chrome Extensiont"
-image: "img/p2_hacking_sustainability/g12_carbon_tracker/tracker_screenshot.png"
+image: "../img/p2_hacking_sustainability/g12_carbon_tracker/tracker_screenshot.png"
 summary: "This project created a Chrome extension to track carbon emission when visiting websites."
 paper: "https://github.com/GustavLeth/Sustainable_Software_Engineering/blob/main/Carbon_Tracker_Report___Sustainable_Software_Engineering.pdf"
 source: "https://github.com/GustavLeth/Sustainable_Software_Engineering"

--- a/2023/p2_hacking_sustainability/g2_JumboExtension.md
+++ b/2023/p2_hacking_sustainability/g2_JumboExtension.md
@@ -2,6 +2,6 @@
 author: Louise Leibbrandt, Nienke Nijkamp, Gaspar Rocha, George Vegelien
 title: "Food Carbon Emission Extension"
 summary: "People are aware that their diet has an ecological impact, but taking action is difficult. We offer a tool that provides consumers with information on the carbon footprint of the food they purchase."
-paper: "papers/SSE_g2_p2_paper.pdf"
+paper: "../papers/SSE_g2_p2_paper.pdf"
 source: "https://github.com/GasparinoRocha/SSE_Project2"
 ---

--- a/2023/p2_hacking_sustainability/gX_template.md
+++ b/2023/p2_hacking_sustainability/gX_template.md
@@ -1,9 +1,9 @@
 ---
 author: Student1 first and last name, Student2, Student3
 title: "Title of the project"
-image: "img/p2_hacking_sustainability/gX_template/cover.png"
+image: "../img/p2_hacking_sustainability/gX_template/cover.png"
 summary: "This is a summary with a max of 200 characters; Lorem ipsum dolor sit amet, consectetur adipisicing elit, dos eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis."
-paper: "papers/gX_template.pdf"
+paper: "../papers/gX_template.pdf"
 source: "https://github.com/luiscruz/course_sustainableSE"
 website: https://luiscruz.github.io/course_sustainableSE/2023/
 ---

--- a/2023/p2_hacking_sustainability/index.md
+++ b/2023/p2_hacking_sustainability/index.md
@@ -11,10 +11,10 @@ exclude: False
 {% if article.image %}
 <img class="p2-img" src="{{article.image}}"/>
 {% endif %}
-  <strong>{{ article.title }}</strong><br/>
+  <strong><a href="{{ article.url | relative_url }}">{{ article.title }}</a></strong><br/>
 <small>_By {{ article.author }}_.</small>
 <br/>
-<small>{{ article.summary | truncate: 200 }}</small>
+<small>{{ article.summary | truncate: 350 }}</small>
 <br/>
 <small>[Paper]({{article.paper}}).</small>
 {%- if article.website %}


### PR DESCRIPTION
We optimized our report for the markdown view like in the previous assignment, but it was not accessible by link. This PR changes that and moves p2.md to index.md in p2_hacking_sustainability directory. Changed the already published reports links accordingly. Also increased summary size due to cut off summaries and the thumbnails were a bit buggy, which this solves.