### PR TITLE
Fix link to group 8's paper.

### DIFF
--- a/2023/p2_hacking_sustainability/g8_vscode_measurements.md
+++ b/2023/p2_hacking_sustainability/g8_vscode_measurements.md
@@ -2,6 +2,6 @@
 author: Ole Peder Brandtzæg, Aaron van Diepen, Rolf Piepenbrink & Jasper Teunissen
 title: "VS Code Power Measurement: A VS Code Extension for Measuring Power Consumption"
 summary: "This paper presents a VS Code extension utilising the energy consumption metrology agent Scaphandre in order to bring power measurements into the IDE."
-paper: "papers/g8_vscode_measurements.pdf"
+paper: "../papers/g8_vscode_measurements.pdf"
 source: "https://github.com/VSCode-Power-Measurement/extension"
 ---


### PR DESCRIPTION
Quick follow-up!

I didn't realise the location of the papers directory had changed, so the link to our paper is currently broken; this PR fixes that.

Thanks!